### PR TITLE
fix(views): call navigation callbacks before async ops to prevent unmounting

### DIFF
--- a/views/ProductView.tsx
+++ b/views/ProductView.tsx
@@ -77,6 +77,8 @@ const ProductView = ({
   }
 
   const handleIDontNeedIt = async () => {
+    onShowIDontNeedIt(product)
+
     if (product) {
       try {
         await ProductActionManager.dontNeedIt(product)
@@ -84,10 +86,11 @@ const ProductView = ({
         console.error("[ProductView] Failed to execute dontNeedIt:", error)
       }
     }
-    onShowIDontNeedIt(product)
   }
 
   const handleINeedIt = async () => {
+    onShowINeedIt()
+
     if (product) {
       try {
         await ProductActionManager.needIt(product)
@@ -95,7 +98,6 @@ const ProductView = ({
         console.error("[ProductView] Failed to execute needIt:", error)
       }
     }
-    onShowINeedIt()
   }
 
   const handleCloseClick = () => {


### PR DESCRIPTION
## Summary

Call `onShowIDontNeedIt` and `onShowINeedIt` **before** the async storage operations instead of after. This ensures the UI transitions immediately when the user clicks, avoiding component unmounting during async work.

## Changes

- **views/ProductView.tsx**: Move `onShowIDontNeedIt(product)` and `onShowINeedIt()` to the start of `handleIDontNeedIt` and `handleINeedIt` respectively, before `ProductActionManager.dontNeedIt/needIt` calls.

## Breaking changes

None.

## Testing

- Manual: Click "I don't need it" / "I need it" — celebration view should appear immediately.
- E2E: `npm run test:e2e` (idontneedit, ineedit flows).

Made with [Cursor](https://cursor.com)