### PR TITLE
ci(e2e): add GitHub Actions workflow for E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,53 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.18.0"
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Build extension for testing
+        run: npm run build:test
+      
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+      
+      - name: Run E2E tests
+        run: npm run test:e2e
+        env:
+          CI: true
+      
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+      
+      - name: Upload test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Lint and Format](https://github.com/thinktwiceco/thinktwice-plugin/actions/workflows/lint-and-format.yml/badge.svg)](https://github.com/thinktwiceco/thinktwice-plugin/actions/workflows/lint-and-format.yml)
+[![E2E Tests](https://github.com/thinktwiceco/thinktwice-plugin/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/thinktwiceco/thinktwice-plugin/actions/workflows/e2e-tests.yml)
 
 # ThinkTwice 🤔
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,14 +2,16 @@ import { defineConfig, devices } from "@playwright/test"
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 60000, // 60 seconds per test to handle CI environments
+  timeout: 90000, // Increased for CI environments
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1, // Extensions often require a single worker for persistent context
-  reporter: "html",
+  reporter: process.env.CI ? [["html"], ["github"]] : "html",
   use: {
     trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
     viewport: { width: 1280, height: 720 }
   },
   projects: [


### PR DESCRIPTION
## Summary

- Add e2e-tests.yml workflow with proper extension build step
- Configure Playwright to install browsers with dependencies  
- Add GitHub reporter for CI with test artifacts upload
- Enhance playwright.config.ts with CI-specific settings

## Changes

### New GitHub Actions Workflow (`.github/workflows/e2e-tests.yml`)
- Builds extension before testing (`npm run build:test`)
- Installs Playwright browsers with system dependencies
- Runs tests with CI environment variable
- Uploads test reports and artifacts on failure

### Playwright Configuration Updates
- Increased timeout to 90s for CI environments
- Added GitHub Actions reporter for PR annotations
- Screenshot and video capture on test failures
- Conditional reporters based on CI environment

### Documentation
- Added E2E Tests status badge to README

## ⚠️ Known Issue

Tests may be blocked by Amazon/Walmart anti-bot protection when running from GitHub Actions IPs. Need to address this before enabling the workflow.

## Test Plan

- [ ] Verify workflow runs without errors
- [ ] Check if tests can access Amazon/Walmart or if blocked
- [ ] Review test artifacts on failure


Made with [Cursor](https://cursor.com)